### PR TITLE
Add login

### DIFF
--- a/lib/command-handler.js
+++ b/lib/command-handler.js
@@ -1,8 +1,27 @@
+const fs    = require('fs');
+const homedir = require('os').homedir();
+const path = require('path');
 const login  = require('./commands/login');
 const create = require('./commands/create');
 const deploy = require('./commands/deploy');
 const help   = require('./commands/help');
 const list   = require('./commands/list');
+
+function isAuthenticated() {
+  const configPath = path.join(homedir, '.mothership-cli');
+  const apiTokenPath = path.join(configPath, 'apiToken');
+  let apiToken;
+
+  if (fs.existsSync(apiTokenPath)) {
+    apiToken = fs.readFileSync(apiTokenPath);
+  }
+
+  return apiTokenPath && apiToken;
+}
+
+function logLoginMessage() {
+  console.log('Please login first (see `mothership help`)');
+}
 
 module.exports = async function executeCommand(command, commandArgs) {
   // `command`
@@ -14,14 +33,27 @@ module.exports = async function executeCommand(command, commandArgs) {
   // an array of all remaining arguments after the initial command
   // i.e. `mothership create foo bar baz`
   // commandArgs: ['foo', 'bar', 'baz']
+
   if (command === 'login') {
     await login(commandArgs);
   } else if (command === 'create') {
-    await create(commandArgs);
+    if (isAuthenticated()) {
+      await create(commandArgs);
+    } else {
+      logLoginMessage();
+    }
   } else if (command === 'deploy') {
-    await deploy(commandArgs)
+    if (isAuthenticated()) {
+      await deploy(commandArgs)
+    } else {
+      logLoginMessage();
+    }
   } else if (command === 'list') {
-    await list();
+    if (isAuthenticated()) {
+      await list();
+    } else {
+      logLoginMessage();
+    }
   } else if (command === 'help') {
     await help();
   } else if (command === 'setup') {

--- a/lib/command-handler.js
+++ b/lib/command-handler.js
@@ -1,3 +1,4 @@
+const login  = require('./commands/login');
 const create = require('./commands/create');
 const deploy = require('./commands/deploy');
 const help   = require('./commands/help');
@@ -13,8 +14,9 @@ module.exports = async function executeCommand(command, commandArgs) {
   // an array of all remaining arguments after the initial command
   // i.e. `mothership create foo bar baz`
   // commandArgs: ['foo', 'bar', 'baz']
-
-  if (command === 'create') {
+  if (command === 'login') {
+    await login(commandArgs);
+  } else if (command === 'create') {
     await create(commandArgs);
   } else if (command === 'deploy') {
     await deploy(commandArgs)

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -15,7 +15,7 @@ module.exports = async function create(commandArgs) {
 
   console.log(`Creating '${title}'...`);
 
-  api.post(HOST + '/apps', { title })
+  api.post(HOST + '/api/apps', { title })
   .then((response) => {
     if (response.status === 201) {
       const app = response.data.app;

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -47,7 +47,7 @@ const uploadProject = (appId) => {
       const formHeaders = form.getHeaders();
 
       loading = ora('Uploading project...').start();
-      api.post(HOST + `/apps/${appId}/deploy`, form, {
+      api.post(HOST + `/api/apps/${appId}/deploy`, form, {
         headers: {
           ...formHeaders,
         },
@@ -77,7 +77,7 @@ const subscribeToEvents = (endpoint) => {
 
 const getApps = () => {
   return new Promise((resolve, reject) => {
-    api.get(HOST + '/apps').then((response) => {
+    api.get(HOST + '/api/apps').then((response) => {
       resolve(response.data.apps);
     }).catch((error) => {
       reject(error);

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -3,6 +3,7 @@ const { table } = require('table');
 module.exports = function() {
   const commands = [
     ['Command', 'Action'],
+    ['mothership login username password', 'login to the PAAS with your username and password'],
     ['mothership help', 'Display this menu'],
     ['mothership list', 'Display list of Mothership\'s apps'],
     ['mothership create appname', 'Create an app named \'appname\''],

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -2,7 +2,7 @@ const { api, HOST } = require('../util/api');
 const { table, getBorderCharacters } = require('table');
 
 module.exports = function() {
-  api.get(HOST + '/apps').then((response) => {
+  api.get(HOST + '/api/apps').then((response) => {
     const tableRows = response.data.apps.map(app => {
       return [app.id, app.title, app.databaseId !== null ? 'Y' : 'N', app.url];
     });

--- a/lib/commands/login.js
+++ b/lib/commands/login.js
@@ -1,0 +1,14 @@
+const { api, HOST } = require('../util/api');
+const { table, getBorderCharacters } = require('table');
+
+module.exports = function(commandArgs) {
+  const username = commandArgs[0];
+  const password = commandArgs[1];
+
+  console.log(`username: ${username}, password: ${password}`);
+  // api.post(HOST + '/api/login').then((response) => {
+  // ...
+  // }).catch((error) => {
+  //   console.log(error);
+  // }).finally(() => {});
+}

--- a/lib/commands/login.js
+++ b/lib/commands/login.js
@@ -1,14 +1,22 @@
+const fs = require('fs');
+const homedir = require('os').homedir();
+const path = require('path');
 const { api, HOST } = require('../util/api');
 const { table, getBorderCharacters } = require('table');
 
 module.exports = function(commandArgs) {
-  const username = commandArgs[0];
-  const password = commandArgs[1];
+  api.post(HOST + '/api/login', {
+    username: commandArgs[0],
+    password: commandArgs[1],
+  }).then((response) => {
+    const configPath = path.join(homedir, '.mothership-cli');
 
-  console.log(`username: ${username}, password: ${password}`);
-  // api.post(HOST + '/api/login').then((response) => {
-  // ...
-  // }).catch((error) => {
-  //   console.log(error);
-  // }).finally(() => {});
+    if (!fs.existsSync(configPath)) {
+      fs.mkdirSync(configPath);
+    }
+    
+    fs.writeFileSync(path.join(configPath, 'apiToken'), response.data);
+  }).catch((error) => {
+    console.log(error);
+  }).finally(() => {});
 }

--- a/lib/util/api.js
+++ b/lib/util/api.js
@@ -1,5 +1,18 @@
+const fs    = require('fs');
+const homedir = require('os').homedir();
+const path = require('path');
 const axios = require('axios').default;
+
+const configPath = path.join(homedir, '.mothership-cli');
+const apiTokenPath = path.join(configPath, 'apiToken');
+let apiToken;
+
+if (fs.existsSync(configPath) && fs.existsSync(apiTokenPath)) {
+  apiToken = fs.readFileSync(path.join(configPath, 'apiToken'));
+}
+
 axios.defaults.headers.common['Accept'] = 'application/json';
+axios.defaults.headers.common['Authorization'] = `Bearer ${apiToken}`;
 
 module.exports = {
   HOST: 'http://localhost:3000', // TODO: change this once user sets up / logs in to PaaS

--- a/lib/util/event.js
+++ b/lib/util/event.js
@@ -1,10 +1,24 @@
+const fs    = require('fs');
+const homedir = require('os').homedir();
+const path = require('path');
 const EventSource = require('EventSource');
 const { HOST } = require('./api');
 
 module.exports = {
   listen: (endpoint) => {
     return new Promise((resolve, reject) => {
-      const eventSource = new EventSource(HOST + endpoint);
+      const configPath = path.join(homedir, '.mothership-cli');
+      const apiTokenPath = path.join(configPath, 'apiToken');
+      let apiToken;
+
+      if (fs.existsSync(configPath) && fs.existsSync(apiTokenPath)) {
+        apiToken = fs.readFileSync(path.join(configPath, 'apiToken'));
+      }
+
+      const eventSource = new EventSource(
+        HOST + endpoint,
+        { headers: { 'Authorization': `Bearer ${apiToken}` } }
+      );
 
       const messageHandler = (event) => {
         if (event.lastEventId === '-1') {


### PR DESCRIPTION
This adds a login command to the cli that gets and saves an api token for future requests. It also configures all commands that require authentication to look for and use this token. If a command that needs auth can't find the token, then it returns early and tells the user to run the login command first.

Additionally, we update the endpoints that the cli hits to be the `/api` versions.