### PR TITLE
enable-setup-command

### DIFF
--- a/lib/command-handler.js
+++ b/lib/command-handler.js
@@ -4,6 +4,7 @@ const path = require('path');
 const login  = require('./commands/login');
 const create = require('./commands/create');
 const deploy = require('./commands/deploy');
+const setup = require('./commands/setup');
 const help   = require('./commands/help');
 const list   = require('./commands/list');
 const open   = require('./commands/open');
@@ -64,7 +65,7 @@ module.exports = async function executeCommand(command, commandArgs) {
   } else if (command === 'help' || command === undefined) {
     await help();
   } else if (command === 'setup') {
-    console.log('Mothership setup is under construction.');
+    await setup();
   } else {
     console.log(`Mothership: '${command}' is not a valid command.`);
     console.log(`Run "mothership help" for a list of commands.`);

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -94,6 +94,38 @@ const sshMachine = (machine, command) => {
   });
 };
 
+
+// retryPromiseIfNeeded(fnReturningPromiseToAttempt, failedAttemptCb, maxTries)
+
+// Takes a function, which when called returns a promise.
+// If the promise resolves, retryPromiseIfNeeded resolves with the result.
+// If the promise rejects, it will call the function again `maxTries` times.
+// - After the promise rejects if `failedAttemptCb` is provided, it will be called
+//   before reattempting the Promise.
+// After we've reached the maximum number of retries we reject from the retry function.
+
+const retryPromiseIfNeeded = async (fn, failedAttemptCb, maxTries = 5) => {
+  return new Promise((resolve, reject) => {
+    let attempt = 1;
+
+    const attemptPromise = () => {
+      fn().then((result) => {
+        resolve(result);
+      }).catch((err) => {
+        if (attempt >= maxTries) {
+          reject(err);
+        } else {
+          attempt += 1;
+          if (failedAttemptCb) { failedAttemptCb(err); }
+          attemptPromise();
+        }
+      });
+    };
+
+    attemptPromise();
+  });
+};
+
 const main = async () => {
   const readline = require('readline').createInterface({
     input: process.stdin,
@@ -126,12 +158,20 @@ const main = async () => {
   console.log('');
   console.log('MOTHERSHIP SETUP');
   // Create droplet for PaaS server to run on
-  loading = ora('Creating droplet for Mothership (this may take a few moments)...').start();
-  await createDockerMachine(MOTHERSHIP_NODE_NAME, accessToken).catch(err => {
-    console.log('catch error:');
-    console.log(err);
+  const { execSync } = require('child_process');
+
+  await retryPromiseIfNeeded(() => {
+    loading = ora('Creating droplet for Mothership (this may take a few moments)...').start();
+    return createDockerMachine(MOTHERSHIP_NODE_NAME, accessToken)
+  }, (err) => {
+    execSync(`docker-machine rm -y ${MOTHERSHIP_NODE_NAME}`);
+  }).then(() => {
+    loading.succeed();
+  }).catch(err => {
+    loading.fail();
+    console.log('Could not successfully create node on 5 attempts.');
+    process.exit();
   });
-  loading.succeed();
 
   // Store IP address of Mothership node
   loading = ora('Getting IP address of Mothership node...');
@@ -178,9 +218,19 @@ const main = async () => {
   // (this way, all information about the swarm manager is stored on the Mothership node)
   console.log('');
   console.log('MOTHERSHIP SWARM SETUP');
-  loading = ora('Creating droplet for Mothership swarm manager...').start();
-  result = await sshMachine(mothershipNode, `docker-machine create --driver digitalocean --digitalocean-access-token ${accessToken} ${SWARM_MANAGER_NODE_NAME}`);
-  loading.succeed();
+
+  await retryPromiseIfNeeded(() => {
+    loading = ora('Creating droplet for Mothership swarm manager...').start();
+    return sshMachine(mothershipNode, `docker-machine create --driver digitalocean --digitalocean-access-token ${accessToken} ${SWARM_MANAGER_NODE_NAME}`);
+  }, async (err) => {
+    await sshMachine(mothershipNode, `docker-machine rm -y ${SWARM_MANAGER_NODE_NAME}`).catch(() => {});
+  }).then(() => {
+    loading.succeed();
+  }).catch(err => {
+    loading.fail();
+    console.log('Could not successfully create node on 5 attempts.');
+    process.exit();
+  });
 
   // Get IP address of cluster manager
   loading = ora('Getting IP address...').start();

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -64,19 +64,6 @@ module.exports = {
 }`;
 };
 
-const readline = require('readline').createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
-
-const promptForInput = (prompt) => {
-  return new Promise((resolve, reject) => {
-    readline.question(prompt + '\n> ', (input) => {
-      resolve(input);
-    });
-  });
-};
-
 const createDockerMachine = (name, accessToken) => {
   return new Promise((resolve, reject) => {
     const options = { 'digitalocean-access-token': accessToken };
@@ -108,6 +95,19 @@ const sshMachine = (machine, command) => {
 };
 
 const main = async () => {
+  const readline = require('readline').createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const promptForInput = (prompt) => {
+    return new Promise((resolve, reject) => {
+      readline.question(prompt + '\n> ', (input) => {
+        resolve(input);
+      });
+    });
+  };
+
   let result;
   let loading;
   console.clear();
@@ -254,4 +254,6 @@ dockerflow/docker-flow-proxy`);
   process.exit();
 };
 
-main();
+module.exports = async function() {
+  main();
+}

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -1,5 +1,7 @@
 const Docker = require('dockerode');
 const DockerMachine = require('docker-machine');
+const Readline = require('readline');
+
 const fs = require('fs');
 const ora = require('ora');
 const { table } = require('table');
@@ -94,6 +96,19 @@ const sshMachine = (machine, command) => {
   });
 };
 
+const promptForInput = (prompt) => {
+  return new Promise((resolve, reject) => {
+    const readline = Readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    readline.question(prompt + '\n> ', (input) => {
+      readline.close();
+      resolve(input);
+    });
+  });
+};
 
 // retryPromiseIfNeeded(fnReturningPromiseToAttempt, failedAttemptCb, maxTries)
 
@@ -127,19 +142,6 @@ const retryPromiseIfNeeded = async (fn, failedAttemptCb, maxTries = 5) => {
 };
 
 const main = async () => {
-  const readline = require('readline').createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  const promptForInput = (prompt) => {
-    return new Promise((resolve, reject) => {
-      readline.question(prompt + '\n> ', (input) => {
-        resolve(input);
-      });
-    });
-  };
-
   let result;
   let loading;
   console.clear();
@@ -300,7 +302,6 @@ dockerflow/docker-flow-proxy`);
   console.log(table(output));
   console.log(`After adding these resource records visit Mothership online: http://mothership.${domain}`);
 
-  readline.close();
   process.exit();
 };
 

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -5,6 +5,7 @@ const Readline = require('readline');
 const fs = require('fs');
 const ora = require('ora');
 const { table } = require('table');
+const { spawnSync } = require('child_process');
 
 const MOTHERSHIP_NODE_NAME = 'mothership-paas';
 const SWARM_MANAGER_NODE_NAME = 'mothership-swarm';
@@ -160,13 +161,12 @@ const main = async () => {
   console.log('');
   console.log('MOTHERSHIP SETUP');
   // Create droplet for PaaS server to run on
-  const { execSync } = require('child_process');
 
   await retryPromiseIfNeeded(() => {
     loading = ora('Creating droplet for Mothership (this may take a few moments)...').start();
     return createDockerMachine(MOTHERSHIP_NODE_NAME, accessToken)
   }, (err) => {
-    execSync(`docker-machine rm -y ${MOTHERSHIP_NODE_NAME}`);
+    spawnSync(`docker-machine rm -y ${MOTHERSHIP_NODE_NAME}`);
   }).then(() => {
     loading.succeed();
   }).catch(err => {


### PR DESCRIPTION
* Enables `mothership setup` command, which is for deploying the PaaS itself
* More gracefully handle `docker-machine create` errors:
  * If a `docker-machine create` command fails, we now attempt to remove the machine it was creating, and we try creating again. We attempt this process at most 5 times, if creation wasn't successful any of those times, we give up completely.
  * _Why are we handling errors anyhow?_
    * Although rare, a race condition can cause `docker-machine create` to fail (this is confirmed on using the DigitalOcean driver, haven't tested other providers yet). This is random, and fairly rare. This PR attempts to handle such situations by re-attempting to create the machine if something went wrong.