### PR TITLE
docker-machine-remove-fix

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -166,7 +166,7 @@ const main = async () => {
     loading = ora('Creating droplet for Mothership (this may take a few moments)...').start();
     return createDockerMachine(MOTHERSHIP_NODE_NAME, accessToken)
   }, (err) => {
-    spawnSync(`docker-machine rm -y ${MOTHERSHIP_NODE_NAME}`);
+    spawnSync(`docker-machine rm -y ${MOTHERSHIP_NODE_NAME}`, [], { shell: true });
   }).then(() => {
     loading.succeed();
   }).catch(err => {


### PR DESCRIPTION
- Updates `spawnSync` call to use shell for the `docker-machine rm` command