### PR TITLE
update-setup-with-environment-variables

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -255,8 +255,8 @@ dockerflow/docker-flow-proxy`);
   loading.succeed();
 
   // Runs seed file
-  loading = ora('Inserting configuration settings into Mothership\'s database...');
-  result = await sshMachine(mothershipNode, `docker-compose exec -T web ./node_modules/.bin/sequelize db:seed --seed config-seed.js`);
+  loading = ora('Seeding Mothership\'s database...');
+  result = await sshMachine(mothershipNode, `docker-compose run web ./node_modules/.bin/sequelize db:seed:all`);
   loading.succeed();
 
   // We're now done! Prints info on what needs added to their DNS and the IP where the Node.js app lives.

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -166,11 +166,6 @@ const main = async () => {
   const mothershipNode = new DockerMachine(MOTHERSHIP_NODE_NAME);
   loading.succeed();
 
-  // Install PaaS to Mothership node
-  loading = ora('Creating docker-compose.yml for Mothership...').start();
-  result = await sshMachine(mothershipNode, `echo "${DOCKER_COMPOSE_CONTENT}" >> docker-compose.yml`)
-  loading.succeed();
-
   // Docker Machine and Docker Compose aren't installed by default on nodes you create with Docker Machine
   // TODO: either clean this up, or run our PaaS app without docker-compose?
   loading = ora('Installing docker-compose...').start();
@@ -183,18 +178,6 @@ const main = async () => {
   curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/tmp/docker-machine &&
   sudo mv /tmp/docker-machine /usr/local/bin/docker-machine &&
   chmod +x /usr/local/bin/docker-machine`);
-  loading.succeed();
-
-  loading = ora('Starting Mothership server (Node.js + Postgres)...').start();
-  result = await sshMachine(mothershipNode, `docker-compose up -d`);
-  loading.succeed();
-
-  loading = ora('Creating database for Mothership...').start();
-  result = await sshMachine(mothershipNode, `docker-compose run web ./node_modules/.bin/sequelize db:create`);
-  loading.succeed();
-
-  loading = ora('Running migrations for Mothership database...').start();
-  result = await sshMachine(mothershipNode, `docker-compose run web ./node_modules/.bin/sequelize db:migrate`);
   loading.succeed();
 
   // Create swarm manager node FROM Mothership node
@@ -252,11 +235,23 @@ dockerflow/docker-flow-proxy`);
   loading.succeed();
 
   console.log('');
-  console.log('MOTHERSHIP CONFIG');
-  // Writes a seed file into the running Node.js web container with initial Config and Node db rows
-  loading = ora('Writing file with Mothership\'s configuration settings...');
-  result = await sshMachine(mothershipNode, `echo "${dbSeedContent('mothership-swarm', swarmManagerIp, domain)}" >> ./config-seed.js`);
-  result = await sshMachine(mothershipNode, `docker cp config-seed.js root_web_1:/usr/src/app/seeders/config-seed.js`);
+  console.log('MOTHERSHIP CONFIG AND START');
+
+  // Install + Start PaaS to Mothership node
+  loading = ora('Creating docker-compose.yml for Mothership...').start();
+  result = await sshMachine(mothershipNode, `echo "${dockerComposeContent(domain, swarmManagerIp)}" >> docker-compose.yml`)
+  loading.succeed();
+
+  loading = ora('Starting Mothership server (Node.js + Postgres)...').start();
+  result = await sshMachine(mothershipNode, `docker-compose up -d`);
+  loading.succeed();
+
+  // loading = ora('Creating database for Mothership...').start();
+  // result = await sshMachine(mothershipNode, `docker-compose run web ./node_modules/.bin/sequelize db:create`);
+  // loading.succeed();
+
+  loading = ora('Running migrations for Mothership database...').start();
+  result = await sshMachine(mothershipNode, `docker-compose run web ./node_modules/.bin/sequelize db:migrate`);
   loading.succeed();
 
   // Runs seed file

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -10,7 +10,8 @@ const { spawnSync } = require('child_process');
 const MOTHERSHIP_NODE_NAME = 'mothership-paas';
 const SWARM_MANAGER_NODE_NAME = 'mothership-swarm';
 // TODO: Change the `image` from this file to point at our team repo (once we make on)
-const DOCKER_COMPOSE_CONTENT = `version: '3'
+const dockerComposeContent = (domain, swarmManagerIp) => {
+  return `version: '3'
 
 services:
   web:
@@ -18,53 +19,33 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/.docker:/root/.docker
+    environment:
+      - NODE_ENV=production
+      - SESSION_SECRET=super_secret
+      - REDIS_HOST=redis
+      - DB_USERNAME=postgres
+      - DB_NAME=paas_development
+      - DB_HOST=database
+      - DB_PASSWORD=password
+      - MOTHERSHIP_DOMAIN=${domain}
+      - MOTHERSHIP_MANAGER_NAME=${SWARM_MANAGER_NODE_NAME}
+      - MOTHERSHIP_MANAGER_IP=${swarmManagerIp}
     ports:
       - "80:3000"
 
   database:
     image: postgres
+    environment:
+      - POSTGRES_DB=paas_development
+      - POSTGRES_PASSWORD=password
     volumes:
       - db_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis
+
 volumes:
-  db_data:`;
-
-const dbSeedContent = (swarmManagerName, swarmManagerIp, domain) => {
-  return `'use strict';
-module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.bulkInsert('Nodes', [
-      {
-        name: '${swarmManagerName}',
-        ip_address: '${swarmManagerIp}',
-        manager: true,
-        createdAt: Sequelize.literal('NOW()'),
-        updatedAt: Sequelize.literal('NOW()'),
-      }
-    ]).then(() => {
-      return queryInterface.bulkInsert('Configs', [
-        {
-          key: 'domain',
-          value: '${domain}',
-          createdAt: Sequelize.literal('NOW()'),
-          updatedAt: Sequelize.literal('NOW()'),
-        },
-        {
-          key: 'proxyNetwork',
-          value: 'proxy',
-          createdAt: Sequelize.literal('NOW()'),
-          updatedAt: Sequelize.literal('NOW()'),
-        }
-      ]);
-    });
-  },
-
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.bulkDelete('Nodes', null, {}).then(() => {
-      return queryInterface.bulkDelete('Configs', null, {});
-    });
-  },
-}`;
+  db_data:`
 };
 
 const createDockerMachine = (name, accessToken) => {

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -4,6 +4,7 @@ const Readline = require('readline');
 
 const fs = require('fs');
 const ora = require('ora');
+const crypto = require('crypto');
 const { table } = require('table');
 const { spawnSync } = require('child_process');
 
@@ -11,6 +12,9 @@ const MOTHERSHIP_NODE_NAME = 'mothership-paas';
 const SWARM_MANAGER_NODE_NAME = 'mothership-swarm';
 // TODO: Change the `image` from this file to point at our team repo (once we make on)
 const dockerComposeContent = (domain, swarmManagerIp) => {
+  const buf = crypto.randomBytes(256);
+  const sessionSecret = buf.toString('hex');
+
   return `version: '3'
 
 services:
@@ -21,7 +25,7 @@ services:
       - /root/.docker:/root/.docker
     environment:
       - NODE_ENV=production
-      - SESSION_SECRET=super_secret
+      - SESSION_SECRET=${sessionSecret}
       - REDIS_HOST=redis
       - DB_USERNAME=postgres
       - DB_NAME=paas_development


### PR DESCRIPTION
This PR updates the setup script in a number of ways:

- Sets required environment variables in generated `docker-compose.yml` file for PaaS
- Removes generation of a setup script-specific seed file
  - The PaaS itself will now have a base seed file that the deploy script will utilize
  - The base seed file will leverage environment variables for values to seed
- Reorders the steps for deployment. (The step which generates/executes to the `docker-compose.yml` file to start the server needs to happen _after_ we've created the cluster manager node, so we can set some environment variables at start of the server)